### PR TITLE
use PIL resize instead of scipy imresize

### DIFF
--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -5,12 +5,24 @@ import ntpath
 import time
 from . import util, html
 from subprocess import Popen, PIPE
-from scipy.misc import imresize
+# from scipy.misc import imresize
+from PIL import Image
 
 if sys.version_info[0] == 2:
     VisdomExceptionBase = Exception
 else:
     VisdomExceptionBase = ConnectionError
+
+def imresize(img, size, resample):
+    switch = {
+        'bicubic': Image.BICUBIC,
+        'nearest': Image.NEAREST,
+        'box': Image.BOX,
+        'bilinear': Image.BILINEAR,
+        'hamming': Image.HAMMING,
+        'lanczos': Image.LANCZOS
+    }
+    return numpy.array(Image.fromarray(img).resize(size, switch[resample]))
 
 
 def save_images(webpage, visuals, image_path, aspect_ratio=1.0, width=256):


### PR DESCRIPTION
According to scipy's [documentation](https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imresize.html) `scipy.misc.imresize` is deprecated and has been removed:

> imresize is deprecated! imresize is deprecated in SciPy 1.0.0, and will be removed in 1.3.0. Use Pillow instead: numpy.array(Image.fromarray(arr).resize()).