### PR TITLE
speed up computation of `log_m_k` and `log_s_k`

### DIFF
--- a/models/monet_model.py
+++ b/models/monet_model.py
@@ -81,10 +81,7 @@ class MONetModel(BaseModel):
         for k in range(self.opt.num_slots):
             # Derive mask from current scope
             if k != self.opt.num_slots - 1:
-                log_alpha_k = self.netAttn(self.x, log_s_k)
-                log_m_k = log_s_k + log_alpha_k
-                # Compute next scope
-                log_s_k += (1. - log_alpha_k.exp()).clamp(min=self.eps).log()
+                log_m_k, log_s_k = self.netAttn(self.x, log_s_k)
             else:
                 log_m_k = log_s_k
 

--- a/models/networks.py
+++ b/models/networks.py
@@ -795,4 +795,4 @@ class Attention(nn.Module):
         log_1_m_alpha_k = -alpha_logits + log_alpha_k
         log_new_scope = log_scope + log_alpha_k
         log_mask = log_scope + log_1_m_alpha_k
-        return [log_new_mask, log_new_scope]
+        return [log_mask, log_new_scope]

--- a/models/networks.py
+++ b/models/networks.py
@@ -790,6 +790,9 @@ class Attention(nn.Module):
         x = self.upblock5(x, skip2)
         x = self.upblock6(x, skip1)
         # Output layer
-        x = self.output(x)
-        x = F.logsigmoid(x)
-        return x
+        alpha_logits = self.output(x)
+        log_alpha_k = F.logsigmoid(alpha_logits)
+        log_1_m_alpha_k = -alpha_logits + log_alpha_k
+        log_new_scope = log_scope + log_alpha_k
+        log_mask = log_scope + log_1_m_alpha_k
+        return [log_new_mask, log_new_scope]


### PR DESCRIPTION
The next scope and segmentation mask in log units can be computed more efficiently using the definition of LogSigmoid:

Typically, we would use a sigmoid layer to transform the logits output (i.e., `alpha_logits`) into probabilities:

![image](https://user-images.githubusercontent.com/42578311/94116471-6349ba80-fe4b-11ea-9e75-ab7db70cc962.png)

Using LogSigmoid leads to 

![image](https://user-images.githubusercontent.com/42578311/94116555-7eb4c580-fe4b-11ea-8e77-6abf04676563.png)

It follows from the model description

![image](https://user-images.githubusercontent.com/42578311/94116680-a2780b80-fe4b-11ea-9985-d232c81cf3f2.png)

This aligns with [Burgess et al. (2019)](https://arxiv.org/abs/1901.11390): 
> Both log alpha_k and log (1 - alpha_k) are computed directly in log units from the logits (using the log softmax operation).

(Appendix B.2)
