### PR TITLE
Edit models to be configurable with 'full_res' argument

### DIFF
--- a/models/monet_model.py
+++ b/models/monet_model.py
@@ -25,6 +25,7 @@ class MONetModel(BaseModel):
                             dataset_mode='clevr', niter=int(64e6 // 7e4))
         parser.add_argument('--num_slots', metavar='K', type=int, default=7, help='Number of supported slots')
         parser.add_argument('--z_dim', type=int, default=16, help='Dimension of individual z latent per slot')
+        parser.add_argument('--full_res', action="store_true", help='the image resolution is 128 x 128')
         if is_train:
             parser.add_argument('--beta', type=float, default=0.5, help='weight for the encoder KLD')
             parser.add_argument('--gamma', type=float, default=0.5, help='weight for the mask KLD')
@@ -47,8 +48,8 @@ class MONetModel(BaseModel):
                             ['xm{}'.format(i) for i in range(opt.num_slots)] + \
                             ['x', 'x_tilde']
         self.model_names = ['Attn', 'CVAE']
-        self.netAttn = networks.init_net(networks.Attention(opt.input_nc, 1), gpu_ids=self.gpu_ids)
-        self.netCVAE = networks.init_net(networks.ComponentVAE(opt.input_nc, opt.z_dim), gpu_ids=self.gpu_ids)
+        self.netAttn = networks.init_net(networks.Attention(opt.input_nc, 1, full_res=opt.full_res), gpu_ids=self.gpu_ids)
+        self.netCVAE = networks.init_net(networks.ComponentVAE(opt.input_nc, opt.z_dim, full_res=opt.full_res), gpu_ids=self.gpu_ids)
         # define networks; you can use opt.isTrain to specify different behaviors for training and test.
         if self.isTrain:  # only defined during training time
             self.criterionKL = nn.KLDivLoss(reduction='batchmean')

--- a/models/networks.py
+++ b/models/networks.py
@@ -727,7 +727,7 @@ class AttentionBlock(nn.Module):
 class Attention(nn.Module):
     """Create a Unet-based generator"""
 
-    def __init__(self, input_nc, output_nc, ngf=64):
+    def __init__(self, input_nc, output_nc, ngf=64, full_res=False):
         """Construct a Unet generator
         Parameters:
             input_nc (int)  -- the number of channels in input images
@@ -735,6 +735,7 @@ class Attention(nn.Module):
             num_downs (int) -- the number of downsamplings in UNet. For example, # if |num_downs| == 7,
                                 image of size 128x128 will become of size 1x1 # at the bottleneck
             ngf (int)       -- the number of filters in the last conv layer
+            full_res (bool) -- if True, the image resolution is 128x128. Else, 64x64.
 
         We construct the U-Net from the innermost layer to the outermost layer.
         It is a recursive process.
@@ -748,12 +749,13 @@ class Attention(nn.Module):
         # no resizing occurs in the last block of each path
         # self.downblock6 = AttentionBlock(ngf * 8, ngf * 8, resize=False)
 
+        feat_dim = 64 if full_res else 16
         self.mlp = nn.Sequential(
-            nn.Linear(4 * 4 * ngf * 8, 128),
+            nn.Linear(feat_dim * ngf * 8, 128),
             nn.ReLU(),
             nn.Linear(128, 128),
             nn.ReLU(),
-            nn.Linear(128, 4 * 4 * ngf * 8),
+            nn.Linear(128, feat_dim * ngf * 8),
             nn.ReLU(),
         )
 


### PR DESCRIPTION
When using MONet with 128x128 images, set `full_res` to True for compatibility with ComponentVAE and Attention.